### PR TITLE
feat: By default use Python 3.9.0 base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 4.0.0 (2020-11-02)
+
+- **BREAKING CHANGE:** By default use Python 3.9.0 for base image
+- Add new `py39` flavour
+- Update pip to 20.2.4
+- Update poetry to 1.1.4
+- Update pre-commit to 2.8.2
+- Update tox to 3.20.1
+- Update virtualenv to 20.1.0
+
 # 3.6.0 (2020-09-25)
 
 - Update `py38` image to Python 3.8.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim-buster
+FROM python:3.9.0-slim-buster
 
 LABEL maintainer="Igor Davydenko <iam@igordavydenko.com>"
 LABEL description="Add poetry, pre-commit, and other dev-tools to official Python slim Docker image."
@@ -10,9 +10,9 @@ RUN apt update -qq \
 
 ENV PATH="/root/.local/bin:/root/.poetry/bin:${PATH}"
 
-RUN pip install pip==20.2.3 pre-commit==2.7.1 tox==3.20.0 virtualenv==20.0.31
+RUN pip install pip==20.2.4 pre-commit==2.8.2 tox==3.20.1 virtualenv==20.1.0
 
-ENV POETRY_VERSION=1.0.10
+ENV POETRY_VERSION=1.1.4
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ image.
 ## Usage
 
 ```dockerfile
-FROM playpauseandstop/docker-python:3.6.0
+FROM playpauseandstop/docker-python:4.0.0
 ```
 
 ### Included dev-tools
 
-- [pip](https://pip.pypa.io) 20.2.3
-- [poetry](https://poetry.eustace.io) 1.0.10
-- [pre-commit](https://pre-commit.com) 2.7.1
-- [tox](https://tox.readthedocs.io/) 3.20.0
-- [virtualenv](https://virtualenv.pypa.io) 20.0.31
+- [pip](https://pip.pypa.io) 20.2.4
+- [poetry](https://python-poetry.org) 1.1.4
+- [pre-commit](https://pre-commit.com) 2.8.2
+- [tox](https://tox.readthedocs.io/) 3.20.1
+- [virtualenv](https://virtualenv.pypa.io) 20.1.0
 - [curl](https://curl.haxx.se) 7.64.0
 - [git](https://git-scm.com) 2.20.1
 - [locales](https://packages.debian.org/stretch/locales) &
@@ -37,6 +37,11 @@ other versions supported as well.
 
 List of supported Python versions are (`<PY_VERSION>` -> base Docker image):
 
+#### 4.0.0
+
+- `py39` -> `python:3.9.0-slim-buster`
+- `py36`, `py37` & `py38` use same base image as in `3.6.0`
+
 #### 3.6.0
 
 - `py38` -> `python:3.8.6-slim-buster`
@@ -46,7 +51,7 @@ List of supported Python versions are (`<PY_VERSION>` -> base Docker image):
 #### 3.5.0
 
 - `py38` -> `python:3.8.5-slim-buster`
-- `py37` & `py36` uses same as in `3.4.0`
+- `py37` & `py36` use same base image as in `3.4.0`
 
 #### 3.4.0
 
@@ -58,12 +63,12 @@ List of supported Python versions are (`<PY_VERSION>` -> base Docker image):
 
 - `py38` -> `python:3.8.3-slim-buster`
 - `py37` -> `python:3.7.7-slim-buster`
-- `py36` uses same version as in `3.1.0`
+- `py36` uses same base image as in `3.1.0`
 
 #### 3.2.0
 
 - `py38` -> `python:3.8.2-slim-buster`
-- `py37` & `py36` uses same version as in `3.1.0`
+- `py37` & `py36` use same base image as in `3.1.0`
 
 #### 3.1.0
 


### PR DESCRIPTION
- Add new `py39` flavour
- Update pip to 20.2.4
- Update poetry to 1.1.4
- Update pre-commit to 2.8.2
- Update tox to 3.20.1
- Update virtualenv to 20.1.0

Fixes: #3