### PR TITLE
Use docker multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,55 @@
-FROM python:3.9.1-slim-buster
+FROM python:3.9.1-slim-buster as python-base
 
 LABEL maintainer="Igor Davydenko <iam@igordavydenko.com>"
 LABEL description="Add poetry, pre-commit, and other dev-tools to official Python slim Docker image."
 
+# poetry envirnment
+ENV POETRY_HOME="/opt/poetry"
+ENV POETRY_NO_INTERACTION=1
+
+# versions
+ENV POETRY_VERSION=1.1.4
+ENV PIP_VERSION 20.3.3
+ENV PRE_COMMIT_VERSION 2.9.3
+ENV TOX_VERSION 3.20.1
+ENV VIRTUALENV_VERSION 20.2.2
+
+# additonal applications to install
+ENV ADDITIONAL_APPS \
+    curl \
+    gettext \
+    git \
+    locales \
+    locales-all \
+    make \
+    nano \
+    openssh-client \
+    rsync
+
+# prepend poetry
+ENV PATH="$POETRY_HOME/bin:$PATH"
+
 RUN apt update -qq \
     && apt upgrade -y \
-    && apt install -y curl gcc g++ gettext git locales locales-all make nano openssh-client rsync \
     && apt autoremove -y
 
-ENV PATH="/root/.local/bin:/root/.poetry/bin:${PATH}"
-
-RUN pip install pip==20.3.3 pre-commit==2.9.3 tox==3.20.1 virtualenv==20.2.2
-
-ENV POETRY_VERSION=1.1.4
+FROM python-base as poetry-builder-base
+RUN apt install -y \
+    curl \
+    build-essential
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+RUN poetry --version
+
+
+FROM python-base as development-base
+RUN apt install -y $ADDITIONAL_APPS && apt autoremove -y
+RUN pip install \
+    pip==$PIP_VERSION \
+    pre-commit==$PRE_COMMIT_VERSION \
+    tox==$TOX_VERSION \
+    virtualenv==$VIRTUALENV_VERSION
+
+COPY --from=poetry-builder-base $POETRY_HOME $POETRY_HOME
 
 WORKDIR /app
 CMD ["python3"]


### PR DESCRIPTION
This MR introduces some refactoring of the Dockerfile such as:
- multistage build, where the poetry is installed in a separate stage and then the binary to be copied to the development stage (without build deps)
- versions, and dependencies are moved to the top as env vars

Using this approach allows the image to reduce from 829MB -> 675MB