### PR TITLE
chore: 5.0.0 Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: "CI"
 on:
   push:
     branches: ["master"]
-    tags: ["v*"]
+    tags: ["*"]
   pull_request:
     branches: ["master"]
 

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -1,0 +1,61 @@
+defaults:
+  run:
+    shell: "bash"
+
+name: "Auto Create Release Tag"
+
+on:
+  pull_request:
+    types: ["closed"]
+
+env:
+  BADABUMP_VERSION: "21.3.3"
+  PYTHON_VERSION: "3.10.0"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  create_release_tag:
+    if: "${{ startsWith(github.head_ref, 'chore/release-') && github.event.pull_request.merged == true }}"
+    name: "Auto Create Release Tag"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - id: "token"
+        uses: "tibdex/github-app-token@v1.5"
+        with:
+          app_id: "${{ secrets.BADABUMP_APP_ID }}"
+          private_key: "${{ secrets.BADABUMP_APP_PRIVATE_KEY }}"
+
+      - uses: "actions/checkout@v2.4.0"
+        with:
+          ref: "master"
+          token: "${{ steps.token.outputs.token }}"
+
+      - name: "Install Python"
+        uses: "actions/setup-python@v2.2.2"
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: "Install badabump"
+        run: "python3 -m pip install badabump==${{ env.BADABUMP_VERSION }}"
+
+      - id: "badabump"
+        name: "Run badabump"
+        run: "python3 -m badabump.ci prepare_tag"
+
+      - name: "Save tag message into the file"
+        run: |
+          with open("./tag_message.txt", "w+") as handler:
+              handler.write("""${{ steps.badabump.outputs.tag_message }}""")
+        shell: "python"
+
+      - name: "Create release tag from latest commit"
+        run: |
+          set -euo pipefail
+
+          git config user.name badabump-release-bot[bot]
+          git config user.email badabump-release-bot[bot]@users.noreply.github.com
+
+          git tag -a ${{ steps.badabump.outputs.tag_name }} -F ./tag_message.txt
+          git push --tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
-# 4.4.0 (In Development)
+# 5.0.0 (2021-11-08)
 
+Update default Python version to use to 3.10.0, as well as use latest `slim-bullseye` image instead of `slim-buster`.
+
+On top of that, install poetry, pre-commit, and tox via pipx, while still install latest pip, pipx, and virtualenv via pip.
+
+**Full list of updates:**
+
+- Provide `py310` image based on `python:3.10.0-slim-bullseye`
 - Update `py39` image to Python 3.9.7
-- Update poetry to 1.1.10
-- Use `install-python.py` script instead of `get-poetry.py` to install poetry
-- Update pip to 21.2.4
+- Update `py38` image to Python 3.8.12
+- Update `py37` image to Python 3.7.12
+- Update `py36` image to Python 3.6.15
+- Update pip to 21.3.1
+- Install pipx 0.16.4
+- Update poetry to 1.1.11
 - Update pre-commit to 2.15.0
-- Update tox to 3.24.4
-- Update virtualenv to 20.8.8
+- Update tox to 3.24.2
+- Update virtualenv to 20.10.0
+- Update versions of all system dev tools to ones, which used in Debian Bullseye
 
 # 4.3.0 (2021-05-09)
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ FROM playpauseandstop/docker-python:5.0.0
 - [pre-commit](https://pre-commit.com) 2.15.0
 - [tox](https://tox.readthedocs.io/) 3.24.2
 - [virtualenv](https://virtualenv.pypa.io) 20.10.0
-- [curl](https://curl.haxx.se) 7.64.0
-- [gcc & g++](https://gcc.gnu.org) 8.3.0
-- [git](https://git-scm.com) 2.20.1
+- [curl](https://curl.haxx.se) 7.74.0
+- [gcc & g++](https://gcc.gnu.org) 10.2.1
+- [git](https://git-scm.com) 2.30.2
 - [locales](https://packages.debian.org/stretch/locales) &
   [locales-all](https://packages.debian.org/stretch/locales-all)
-- [make](https://www.gnu.org/software/make) 4.2.1
-- [nano](https://www.nano-editor.org) 3.2
-- [gettext](https://www.gnu.org/software/gettext) 0.19.8.1
-- [openssh-client](https://packages.debian.org/stretch/openssh-client) 7.9p1
-- [rsync](https://rsync.samba.org) 3.1.3
+- [make](https://www.gnu.org/software/make) 4.3
+- [nano](https://www.nano-editor.org) 5.4
+- [gettext](https://www.gnu.org/software/gettext) 0.21
+- [openssh-client](https://packages.debian.org/stretch/openssh-client) 8.4p1
+- [rsync](https://rsync.samba.org) 3.2.3
 
 ### Python versions
 
@@ -39,7 +39,7 @@ List of supported Python versions are (`<PY_VERSION>` -> base Docker image)
 #### 5.0.0
 
 - `py310` -> `python:3.10.0-slim-bullseye`
-- `py39` -> `python:3.9.8-slim-bullseye`
+- `py39` -> `python:3.9.7-slim-bullseye`
 - `py38` -> `python:3.8.12-slim-bullseye`
 - `py37` -> `python:3.7.12-slim-bullseye`
 - `py36` -> `python:3.6.15-slim-bullseye`


### PR DESCRIPTION
Update default Python version to use to 3.10.0, as well as use latest `slim-bullseye` image instead of `slim-buster`.

On top of that, install poetry, pre-commit, and tox via pipx, while still install latest pip, pipx, and virtualenv via pip.

**Full list of updates:**

- Provide `py310` image based on `python:3.10.0-slim-bullseye`
- Update `py39` image to Python 3.9.7
- Update `py38` image to Python 3.8.12
- Update `py37` image to Python 3.7.12
- Update `py36` image to Python 3.6.15
- Update pip to 21.3.1
- Install pipx 0.16.4
- Update poetry to 1.1.11
- Update pre-commit to 2.15.0
- Update tox to 3.24.2
- Update virtualenv to 20.10.0
- Update versions of all system dev tools to ones, which used in Debian Bullseye