### PR TITLE
ci: Provide badabump config

### DIFF
--- a/.badabump.toml
+++ b/.badabump.toml
@@ -1,0 +1,2 @@
+[tool.badabump]
+tag_format = "{version}"


### PR DESCRIPTION
To not prefix git tags with `v`.