### PR TITLE
chore: 5.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.1.0 (2021-12-19)
+
+- Update `py310` image to Python 3.10.1
+- Update `py39` image to Python 3.9.9
+- Update poetry to 1.1.12
+- Update pre-commit to 2.16.0
+
 # 5.0.0 (2021-11-08)
 
 Update default Python version to use to 3.10.0, as well as use latest `slim-bullseye` image instead of `slim-buster`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0-slim-bullseye as python-base
+FROM python:3.10.1-slim-bullseye as python-base
 
 LABEL maintainer="Igor Davydenko <iam@igordavydenko.com>"
 LABEL description="Add poetry, pre-commit and tox installed via pipx as well as other system dev tools to official Python slim Docker image."
@@ -37,8 +37,8 @@ ENV PATH="/root/.local/bin:${PATH}"
 # ```
 ENV PIP_VERSION="21.3.1"
 ENV PIPX_VERSION="0.16.4"
-ENV POETRY_VERSION="1.1.11"
-ENV PRE_COMMIT_VERSION="2.15.0"
+ENV POETRY_VERSION="1.1.12"
+ENV PRE_COMMIT_VERSION="2.16.0"
 ENV TOX_VERSION="3.24.4"
 ENV VIRTUALENV_VERSION="20.10.0"
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ FROM playpauseandstop/docker-python:5.0.0
 
 - [pip](https://pip.pypa.io) 21.3.1
 - [pipx](https://pypa.github.io/pipx/) 0.16.4
-- [poetry](https://python-poetry.org) 1.1.11
-- [pre-commit](https://pre-commit.com) 2.15.0
+- [poetry](https://python-poetry.org) 1.1.12
+- [pre-commit](https://pre-commit.com) 2.16.0
 - [tox](https://tox.readthedocs.io/) 3.24.2
 - [virtualenv](https://virtualenv.pypa.io) 20.10.0
 - [curl](https://curl.haxx.se) 7.74.0
@@ -35,6 +35,12 @@ FROM playpauseandstop/docker-python:5.0.0
 By default, `docker-python` image uses latest stable Python version. But some other versions supported as well.
 
 List of supported Python versions are (`<PY_VERSION>` -> base Docker image)
+
+#### 5.1.0
+
+- `py310` -> `python:3.10.1-slim-bullseye`
+- `py39` -> `python:3.9.9-slim-bullseye`
+- `py38`, `py37` & `py36` use same base image as in `5.0.0`
 
 #### 5.0.0
 


### PR DESCRIPTION
- Update `py310` image to 3.10.1
- Update `py39` image to 3.9.9
- Update poetry to 1.1.12
- Update pre-commit to 2.16.0