### PR TITLE
feat: Install pipx into system site packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 5.2.0 (2022-02-16)
+
+- **BREAKING CHANGE:** Do not install `pipx` into user site-packages, install it into the system site-packages and configure to use `/opt/pipx` for venvs and binaries
+- Update `py310` image to Python 3.10.2
+- Update `py39` image to Python 3.9.10
+- Update pip to 22.0.3
+- Update pipx to 1.0.0
+- Update poetry to 1.1.13
+- Update pre-commit to 2.17.0
+- Update tox to 3.24.5
+- Update virtualenv to 20.13.1
+
 # 5.1.0 (2021-12-19)
 
 - Update `py310` image to Python 3.10.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,27 +23,29 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y
 
-# Update path to include `/root/.local/bin` for `pip install --user ...` and
-# `pipx` needs
-ENV PATH="/root/.local/bin:${PATH}"
+# Setup pipx and update `PATH` to include `/opt/pipx/bin` for applications
+# installed via `pipx`
+ENV PIPX_HOME="/opt/pipx/venvs"
+ENV PIPX_BIN_DIR="/opt/pipx/bin"
+ENV PATH="${PIPX_BIN_DIR}:${PATH}"
 
-# Update pip to latest version, install pipx & virtualen into user directory,
-# and install additional dev-tools via pipx into `~/.local`
+# Update pip to latest version, install pipx & virtualenv into the system,
+# and install additional dev-tools via pipx into `PIPX_BIN_DIR`
 #
 # To check latest versions,
 #
 # ```bash
 # pip-latest-release pip pipx poetry pre-commit tox virtualenv
 # ```
-ENV PIP_VERSION="21.3.1"
-ENV PIPX_VERSION="0.16.4"
-ENV POETRY_VERSION="1.1.12"
-ENV PRE_COMMIT_VERSION="2.16.0"
-ENV TOX_VERSION="3.24.4"
-ENV VIRTUALENV_VERSION="20.10.0"
+#
+ENV PIP_VERSION="22.0.3"
+ENV PIPX_VERSION="1.0.0"
+ENV POETRY_VERSION="1.1.13"
+ENV PRE_COMMIT_VERSION="2.17.0"
+ENV TOX_VERSION="3.24.5"
+ENV VIRTUALENV_VERSION="20.13.1"
 
-RUN python3 -m pip install --no-cache-dir pip==${PIP_VERSION} \
-    && python3 -m pip install --no-cache-dir --user pipx==${PIPX_VERSION} virtualenv==${VIRTUALENV_VERSION} \
+RUN python3 -m pip install --no-cache-dir pip==${PIP_VERSION} pipx==${PIPX_VERSION} virtualenv==${VIRTUALENV_VERSION} \
     && python3 -m pipx install --pip-args=--no-cache-dir poetry==${POETRY_VERSION} \
     && python3 -m pipx install --pip-args=--no-cache-dir pre-commit==${PRE_COMMIT_VERSION} \
     && python3 -m pipx install --pip-args=--no-cache-dir tox==${TOX_VERSION}

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ FROM playpauseandstop/docker-python:5.0.0
 
 ### Included dev-tools
 
-- [pip](https://pip.pypa.io) 21.3.1
-- [pipx](https://pypa.github.io/pipx/) 0.16.4
-- [poetry](https://python-poetry.org) 1.1.12
-- [pre-commit](https://pre-commit.com) 2.16.0
-- [tox](https://tox.readthedocs.io/) 3.24.2
-- [virtualenv](https://virtualenv.pypa.io) 20.10.0
+- [pip](https://pip.pypa.io) 22.0.3
+- [pipx](https://pypa.github.io/pipx/) 1.0.0
+- [poetry](https://python-poetry.org) 1.1.13
+- [pre-commit](https://pre-commit.com) 2.17.0
+- [tox](https://tox.readthedocs.io/) 3.24.5
+- [virtualenv](https://virtualenv.pypa.io) 20.13.1
 - [curl](https://curl.haxx.se) 7.74.0
 - [gcc & g++](https://gcc.gnu.org) 10.2.1
 - [git](https://git-scm.com) 2.30.2
@@ -35,6 +35,12 @@ FROM playpauseandstop/docker-python:5.0.0
 By default, `docker-python` image uses latest stable Python version. But some other versions supported as well.
 
 List of supported Python versions are (`<PY_VERSION>` -> base Docker image)
+
+#### 5.2.0
+
+- `py310` -> `python:3.10.2-slim-bullseye`
+- `py39` -> `python:3.9.10-slim-bullseye`
+- `py38`, `py37` & `py36` use same base image as in `5.0.0`
 
 #### 5.1.0
 


### PR DESCRIPTION
And configure it to have venvs at `/opt/pipx/venvs`, while installing library binaries into `/opt/pipx/bin`.

Also bump pip, poetry, and stuff to latest versions.