### PR TITLE
feat!: Update poetry to 1.2.1 as well as other dev tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,12 @@ ENV PATH="${PIPX_BIN_DIR}:${PATH}"
 # pip-latest-release pip pipx poetry pre-commit tox virtualenv
 # ```
 #
-ENV PIP_VERSION="22.1"
-ENV PIPX_VERSION="1.0.0"
-ENV POETRY_VERSION="1.1.13"
-ENV PRE_COMMIT_VERSION="2.19.0"
-ENV TOX_VERSION="3.25.0"
-ENV VIRTUALENV_VERSION="20.14.1"
+ENV PIP_VERSION="22.2.2"
+ENV PIPX_VERSION="1.1.0"
+ENV POETRY_VERSION="1.2.1"
+ENV PRE_COMMIT_VERSION="2.20.0"
+ENV TOX_VERSION="3.26.0"
+ENV VIRTUALENV_VERSION="20.16.5"
 
 RUN python3 -m pip install --no-cache-dir pip==${PIP_VERSION} pipx==${PIPX_VERSION} virtualenv==${VIRTUALENV_VERSION} \
     && python3 -m pipx install --pip-args=--no-cache-dir poetry==${POETRY_VERSION} \

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ FROM playpauseandstop/docker-python:5.3.0
 
 ### Included dev-tools
 
-- [pip](https://pip.pypa.io) 22.1
-- [pipx](https://pypa.github.io/pipx/) 1.0.0
-- [poetry](https://python-poetry.org) 1.1.13
-- [pre-commit](https://pre-commit.com) 2.19.0
-- [tox](https://tox.readthedocs.io/) 3.25.0
-- [virtualenv](https://virtualenv.pypa.io) 20.14.1
+- [pip](https://pip.pypa.io) 22.2.2
+- [pipx](https://pypa.github.io/pipx/) 1.1.0
+- [poetry](https://python-poetry.org) 1.2.1
+- [pre-commit](https://pre-commit.com) 2.20.0
+- [tox](https://tox.readthedocs.io/) 3.26.0
+- [virtualenv](https://virtualenv.pypa.io) 20.16.5
 - [curl](https://curl.haxx.se) 7.74.0
 - [gcc & g++](https://gcc.gnu.org) 10.2.1
 - [git](https://git-scm.com) 2.30.2


### PR DESCRIPTION
To their latest versions. As well as formally deprecate `py36` image.