### PR TITLE
feat!: Use Python 3.11.0rc2 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.7-slim-bullseye as python-base
+FROM python:3.11.0rc2-slim-bullseye as python-base
 
 LABEL maintainer="Igor Davydenko <iam@igordavydenko.com>"
 LABEL description="Add poetry, pre-commit and tox installed via pipx as well as other system dev tools to official Python slim Docker image."


### PR DESCRIPTION
This time prepare in advance and provide `py311` Docker images before stable 3.11.0 release to allow users try new Python version in advance.