### PR TITLE
chore: 6.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 6.0.0 (2022-09-17)
+
+Update default image to use Python 3.11.0rc2, which hopefully allows image users better prepare to stable 3.11.0 release.
+
+As well as deprecate `py36` flavour altogether, good bye, old friend! It was a great ride!
+
+- **BREAKING CHANGE:** Use Python 3.11.0rc2 as base image
+- **BREAKING CHANGE:** Discount `py36` flavour
+- **BREAKING CHANGE:** Update poetry to 1.2.1
+- Update `py310` image to 3.10.7
+- Update `py39` image to 3.9.14
+- Update `py38` image to 3.8.14
+- Update `py37` image to 3.7.14
+- Update pip to 22.2.2
+- Update pipx to 1.1.0
+- Update pre-commit to 2.20.0
+- Update tox to 3.26.0
+- Update virtualenv to 20.16.5
+
 # 5.3.0 (2022-05-12)
 
 - Update `py310` image to Python 3.10.4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add poetry, pre-commit and tox installed via pipx as well as other system dev to
 ## Usage
 
 ```dockerfile
-FROM playpauseandstop/docker-python:5.3.0
+FROM playpauseandstop/docker-python:6.0.0
 ```
 
 ### Included dev-tools
@@ -35,6 +35,14 @@ FROM playpauseandstop/docker-python:5.3.0
 By default, `docker-python` image uses latest stable Python version. But some other versions supported as well.
 
 List of supported Python versions are (`<PY_VERSION>` -> base Docker image)
+
+#### 6.0.0
+
+- `py311` -> `python:3.11.0rc2-slim-bullseye`
+- `py310` -> `python:3.10.7-slim-bullseye`
+- `py39` -> `python:3.9.14-slim-bullseye`
+- `py38` -> `python:3.8.14-slim-bullseye`
+- `py37` -> `python:3.7.14-slim-bullseye`
 
 #### 5.3.0
 


### PR DESCRIPTION
Update default image to use Python 3.11.0rc2, which hopefully allows image users better prepare to stable 3.11.0 release.

As well as deprecate `py36` flavour altogether, good bye, old friend! It was a great ride!

- **BREAKING CHANGE:** Use Python 3.11.0rc2 as base image
- **BREAKING CHANGE:** Discount `py36` flavour
- **BREAKING CHANGE:** Update poetry to 1.2.1
- Update `py310` image to 3.10.7
- Update `py39` image to 3.9.14
- Update `py38` image to 3.8.14
- Update `py37` image to 3.7.14
- Update pip to 22.2.2
- Update pipx to 1.1.0
- Update pre-commit to 2.20.0
- Update tox to 3.26.0
- Update virtualenv to 20.16.5