### PR TITLE
chore: 6.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 6.1.0 (2022-10-25)
+
+`py311` image now uses **stable** Python 3.11.0 version.
+
+- Update `py311` image to Python 3.11.0
+- Update `py310` image to Python 3.10.8
+- Update `py39` image to Python 3.9.15
+- Update `py38` image to Python 3.8.15
+- Update `py37` image to Python 3.7.15
+- Update pip to 22.3
+- Update poetry to 1.2.2
+- Update virtualenv to 20.16.6
+
 # 6.0.0 (2022-09-17)
 
 Update default image to use Python 3.11.0rc2, which hopefully allows image users better prepare to stable 3.11.0 release.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add poetry, pre-commit and tox installed via pipx as well as other system dev to
 ## Usage
 
 ```dockerfile
-FROM playpauseandstop/docker-python:6.0.0
+FROM playpauseandstop/docker-python:6.1.0
 ```
 
 ### Included dev-tools
@@ -35,6 +35,14 @@ FROM playpauseandstop/docker-python:6.0.0
 By default, `docker-python` image uses latest stable Python version. But some other versions supported as well.
 
 List of supported Python versions are (`<PY_VERSION>` -> base Docker image)
+
+#### 6.1.0
+
+- `py311` -> `python:3.11.0-slim-bullseye`
+- `py310` -> `python:3.10.8-slim-bullseye`
+- `py39` -> `python:3.9.15-slim-bullseye`
+- `py38` -> `python:3.8.15-slim-bullseye`
+- `py37` -> `python:3.7.15-slim-bullseye`
 
 #### 6.0.0
 


### PR DESCRIPTION
`py311` image now uses **stable** Python 3.11.0 version.

- Update `py311` image to Python 3.11.0
- Update `py310` image to Python 3.10.8
- Update `py39` image to Python 3.9.15
- Update `py38` image to Python 3.8.15
- Update `py37` image to Python 3.7.15
- Update pip to 22.3
- Update poetry to 1.2.2
- Update virtualenv to 20.16.6