### PR TITLE
chore: 6.2.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 6.2.0 (2023-01-09)
+
+- Update `py311` image to Python 3.11.1
+- Update `py310` image to Python 3.10.9
+- Update `py39` image to Python 3.9.16
+- Update `py38` image to Python 3.8.16
+- Update `py37` image to Python 3.7.16
+- Update pip to 22.3.1
+- **POSSIBLE BREAKING CHANGE:** Update poetry to 1.3.1
+- Update pre-commit to 2.21.0
+- **POSSIBLE BREAKING CHANGE:** Update tox to 4.2.6
+- Update virtualenv to 20.17.1
+
 # 6.1.0 (2022-10-25)
 
 `py311` image now uses **stable** Python 3.11.0 version.

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,19 @@
-.PHONY: all build deploy run
-
 DOCKER ?= docker
 IMAGE ?= playpauseandstop/docker-python
 TAG ?= latest
 
 all: build
 
+.PHONY: build
 build: .build
 .build: Dockerfile
 	$(DOCKER) build -t $(IMAGE):$(TAG) .
 	touch $@
 
-deploy: build
-	$(DOCKER) push $(IMAGE):$(TAG)
-
+.PHONY: list-versions
 list-versions:
-	pip-latest-release pip pre-commit tox virtualenv
+	./scripts/pip-latest-release.sh pip pipx poetry pre-commit tox virtualenv
 
+.PHONY: run
 run: build
 	$(DOCKER) run --rm -it $(IMAGE):$(TAG) $(ARGS)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add poetry, pre-commit and tox installed via pipx as well as other system dev to
 ## Usage
 
 ```dockerfile
-FROM playpauseandstop/docker-python:6.1.0
+FROM playpauseandstop/docker-python:6.2.0
 ```
 
 ### Included dev-tools
@@ -35,6 +35,14 @@ FROM playpauseandstop/docker-python:6.1.0
 By default, `docker-python` image uses latest stable Python version. But some other versions supported as well.
 
 List of supported Python versions are (`<PY_VERSION>` -> base Docker image)
+
+#### 6.2.0
+
+- `py311` -> `python:3.11.1-slim-bullseye`
+- `py310` -> `python:3.10.9-slim-bullseye`
+- `py39` -> `python:3.9.16-slim-bullseye`
+- `py38` -> `python:3.8.16-slim-bullseye`
+- `py37` -> `python:3.7.16-slim-bullseye`
 
 #### 6.1.0
 
@@ -188,5 +196,11 @@ make
 To run something, using built image:
 
 ```bash
-make ARGS="..." run
+make run ARGS="..."
+```
+
+To list latest versions of Python dev tools, included in the image (this is useful for updating versions in `Dockerfile`):
+
+```bash
+make list-versions
 ```


### PR DESCRIPTION
- Update `py311` image to Python 3.11.1
- Update `py310` image to Python 3.10.9
- Update `py39` image to Python 3.9.16
- Update `py38` image to Python 3.8.16
- Update `py37` image to Python 3.7.16
- Update pip to 22.3.1
- **POSSIBLE BREAKING CHANGE:** Update poetry to 1.3.1
- Update pre-commit to 2.21.0
- **POSSIBLE BREAKING CHANGE:** Update tox to 4.2.6
- Update virtualenv to 20.17.1
