### PR TITLE
build: Set default Python version to use to 3.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim-bullseye as python-base
+FROM python:3.12.1-slim-bookworm as python-base
 
 LABEL maintainer="Igor Davydenko <iam@igordavydenko.com>"
 LABEL description="Add poetry, pre-commit and tox installed via pipx as well as other system dev tools to official Python slim Docker image."
@@ -38,12 +38,12 @@ ENV PATH="${PIPX_BIN_DIR}:${PATH}"
 # ./scripts/pip-latest-release.sh pip pipx poetry pre-commit tox virtualenv
 # ```
 #
-ENV PIP_VERSION="22.3.1"
-ENV PIPX_VERSION="1.1.0"
-ENV POETRY_VERSION="1.3.1"
-ENV PRE_COMMIT_VERSION="2.21.0"
-ENV TOX_VERSION="4.2.6"
-ENV VIRTUALENV_VERSION="20.17.1"
+ENV PIP_VERSION="23.3.2"
+ENV PIPX_VERSION="1.4.3"
+ENV POETRY_VERSION="1.7.1"
+ENV PRE_COMMIT_VERSION="3.6.0"
+ENV TOX_VERSION="4.12.1"
+ENV VIRTUALENV_VERSION="20.25.0"
 
 RUN python3 -m pip install --no-cache-dir pip==${PIP_VERSION} pipx==${PIPX_VERSION} virtualenv==${VIRTUALENV_VERSION} \
     && python3 -m pipx install --pip-args=--no-cache-dir poetry==${POETRY_VERSION} \

--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ FROM playpauseandstop/docker-python:6.2.0
 
 ### Included dev-tools
 
-- [pip](https://pip.pypa.io) 22.3.1
-- [pipx](https://pypa.github.io/pipx/) 1.1.0
-- [poetry](https://python-poetry.org) 1.3.1
-- [pre-commit](https://pre-commit.com) 2.21.0
-- [tox](https://tox.readthedocs.io/) 4.2.6
-- [virtualenv](https://virtualenv.pypa.io) 20.17.1
-- [curl](https://curl.haxx.se) 7.74.0
-- [gcc & g++](https://gcc.gnu.org) 10.2.1
-- [git](https://git-scm.com) 2.30.2
+- [pip](https://pip.pypa.io) 23.3.2
+- [pipx](https://pypa.github.io/pipx/) 1.4.3
+- [poetry](https://python-poetry.org) 1.7.1
+- [pre-commit](https://pre-commit.com) 3.6.0
+- [tox](https://tox.readthedocs.io/) 4.12.1
+- [virtualenv](https://virtualenv.pypa.io) 20.25.0
+- [curl](https://curl.haxx.se) 7.88.1
+- [gcc & g++](https://gcc.gnu.org) 12.2.0
+- [git](https://git-scm.com) 2.39.2
 - [locales](https://packages.debian.org/stretch/locales) &
   [locales-all](https://packages.debian.org/stretch/locales-all)
 - [make](https://www.gnu.org/software/make) 4.3
-- [nano](https://www.nano-editor.org) 5.4
+- [nano](https://www.nano-editor.org) 7.2
 - [gettext](https://www.gnu.org/software/gettext) 0.21
 - [openssh-client](https://packages.debian.org/stretch/openssh-client) 8.4p1
-- [rsync](https://rsync.samba.org) 3.2.3
+- [rsync](https://rsync.samba.org) 3.2.7
 
 ### Python versions
 


### PR DESCRIPTION
As well as start using `-bookworm` flavored images.

On top of that update pip, pipx, and other Python dev tools to latest
versions.
